### PR TITLE
chore: manifest-v3-update

### DIFF
--- a/src/public/manifest.json
+++ b/src/public/manifest.json
@@ -4,7 +4,7 @@
   "version": "2.1.0",
   "browser_specific_settings": {
     "gecko": {
-      "id": "sg-legal-cite"
+      "id": "eugenetham1994@gmail.com"
     }
   },
   "action": {


### PR DESCRIPTION
Support for manifest v3

Do not merge to master as firefox has yet to adopt manifest v3